### PR TITLE
Make configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ pfds is one-binary and supports multi process. It's simple and powerful.
 
 - short version
 
-```
+```sh
 $ sudo pfds short `pgrep nginx` `pgrep httpd` | head
    13963 matsumoto_r /usr/local/apache-2.4.16/htdocs/blog/wp-includes/js/jquery/jquery-migrate.min.js
    13963 matsumoto_r /usr/local/apache-2.4.16/htdocs/blog/wp-includes/js/jquery/jquery.js
@@ -25,7 +25,7 @@ $ sudo pfds short `pgrep nginx` `pgrep httpd` | head
 
 - output with cpu and memory usage
 
-```
+```sh
 $ sudo pfds `pgrep nginx` `pgrep httpd` | sort -nk2 | tail
    13963  0.0  0.3 matsumoto_r /usr/local/apache-2.4.16/htdocs/blog/wp-includes/js/jquery/jquery-migrate.min.js
    13963  0.0  0.3 matsumoto_r /usr/local/apache-2.4.16/htdocs/blog/wp-includes/js/jquery/jquery.js
@@ -43,11 +43,11 @@ $ sudo pfds `pgrep nginx` `pgrep httpd` | sort -nk2 | tail
 
 - Adjust multi process (default 4 process)
 
-```
+```sh
 sudo MRUBY_MULTI=24 pfds `pgrep httpd` 
 ```
 
-```
+```sh
 sudo MRUBY_MULTI=1 pfds `pgrep httpd` 
 ```
 
@@ -61,38 +61,44 @@ module Pfds
 
     MULTI_PROCESS = (ENV["MRUBY_MULTI"] || 4).to_i
 
-    IGNORE_FILES = %w(
+    CONFIG_PATH = '/etc/pfds.json'
 
-    /dev/null
-    /var/log/httpd/access_log
-    /var/log/httpd/ssl_access_log
-    /var/log/httpd/error_log
-    /var/log/httpd/ssl_error_log
-
-    )
-
-    IGNORE_PATTERN = %w(
-
-    ^pipe:
-    ^anon_inode:
-    ^socket:
-    ^/dev/pts/
-
-    )
   end
 end
 ```
 
 - build into `mruby/bin/pfds`
 
-```
+```sh
 rake
 ```
 
 ## install to `/usr/local/bin`
 
-```
+```sh
 rake install
+```
+
+* Also put configration file to `/etc/pfds.json`.
+
+## configure
+
+```sh
+{
+  "ignore_files": [
+    "/dev/null",
+    "/var/log/httpd/access_log",
+    "/var/log/httpd/error_log",
+    "/var/log/httpd/ssl_access_log",
+    "/var/log/httpd/ssl_error_log"
+  ],
+  "ignore_patterns": [
+    "^pipe:",
+    "^anon_inode:",
+    "^socket:",
+    "^/dev/pts/"
+  ]
+}
 ```
 
 # License

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ module Pfds
 
     MULTI_PROCESS = (ENV["MRUBY_MULTI"] || 4).to_i
 
-    CONFIG_PATH = '/etc/pfds.json'
+    CONFIG_PATH = (ENV.key?("PFDS_CONFIG") ? ENV["PFDS_CONFIG"] : "/etc/pfds.json")
 
   end
 end
@@ -100,6 +100,8 @@ rake install
   ]
 }
 ```
+
+* config file path will be set by `PFDS_CONFIG` of `ENV`.
 
 # License
 under the MIT License:

--- a/Rakefile
+++ b/Rakefile
@@ -62,6 +62,7 @@ task :test => ["test:mtest", "test:bintest"]
 desc "install to /usr/local/bin/"
 task :install do
   sh "sudo install -m 755 #{mruby_root}/bin/#{APP_NAME} /usr/local/bin"
+  sh "sudo install -m 644 #{APP_ROOT}/#{APP_NAME}.json /etc"
 end
 
 desc "cleanup"

--- a/build_config.rb
+++ b/build_config.rb
@@ -2,6 +2,7 @@ def gem_config(conf)
   conf.gembox 'full-core'
   conf.gem :mgem => 'mruby-dir'
   conf.gem :mgem => 'mruby-io'
+  conf.gem :mgem => 'mruby-iijson'
   conf.gem :mgem => 'mruby-process'
   conf.gem :mgem => 'mruby-env'
   conf.gem :mgem => 'mruby-mutex'

--- a/mrblib/pfds/config.rb
+++ b/mrblib/pfds/config.rb
@@ -3,7 +3,7 @@ module Pfds
 
     MULTI_PROCESS = (ENV["MRUBY_MULTI"] || 4).to_i
 
-    CONFIG_PATH = '/etc/pfds.json'
+    CONFIG_PATH = (ENV.key?("PFDS_CONFIG") ? ENV["PFDS_CONFIG"] : "/etc/pfds.json")
 
   end
 end

--- a/mrblib/pfds/config.rb
+++ b/mrblib/pfds/config.rb
@@ -3,23 +3,7 @@ module Pfds
 
     MULTI_PROCESS = (ENV["MRUBY_MULTI"] || 4).to_i
 
-    IGNORE_FILES = %w(
+    CONFIG_PATH = '/etc/pfds.json'
 
-    /dev/null
-    /var/log/httpd/access_log
-    /var/log/httpd/ssl_access_log
-    /var/log/httpd/error_log
-    /var/log/httpd/ssl_error_log
-
-    )
-
-    IGNORE_PATTERN = %w(
-
-    ^pipe:
-    ^anon_inode:
-    ^socket:
-    ^/dev/pts/
-
-    )
   end
 end

--- a/pfds.json
+++ b/pfds.json
@@ -1,0 +1,15 @@
+{
+  "ignore_files": [
+    "/dev/null",
+    "/var/log/httpd/access_log",
+    "/var/log/httpd/error_log",
+    "/var/log/httpd/ssl_access_log",
+    "/var/log/httpd/ssl_error_log"
+  ],
+  "ignore_patterns": [
+    "^pipe:",
+    "^anon_inode:",
+    "^socket:",
+    "^/dev/pts/"
+  ]
+}

--- a/test/test_pfds.rb
+++ b/test/test_pfds.rb
@@ -1,18 +1,27 @@
 class TestPfds < MTest::Unit::TestCase
+  @@test_config = {
+    "ignore_files" => [
+      "/var/log/httpd/access_log"
+    ],
+    "ignore_patterns" => [
+      "^socket:"
+    ]
+  }
+
   def test_main
     assert_nil __main__(["self"])
   end
   def test_file_ignore
-    assert_true Pfds.file_ignore?("/var/log/httpd/access_log")
+    assert_true Pfds.file_ignore?("/var/log/httpd/access_log", @@test_config["ignore_files"])
   end
   def test_file_ignore_false
-    assert_false Pfds.file_ignore?("/var/log/httpd/access_log.1")
+    assert_false Pfds.file_ignore?("/var/log/httpd/access_log.1", @@test_config["ignore_files"])
   end
   def test_pattern_ignore
-    assert_true Pfds.pattern_ignore?("socket:00000")
+    assert_true Pfds.pattern_ignore?("socket:00000", @@test_config["ignore_patterns"])
   end
   def test_pattern_ignore_false
-    assert_false Pfds.pattern_ignore?("tcp:00000")
+    assert_false Pfds.pattern_ignore?("tcp:00000", @@test_config["ignore_patterns"])
   end
 end
 


### PR DESCRIPTION
## Summary

`IGNORE_FILES` and `IGNORE_PATTERNS` that was in `config.rb`, are able to set by configuration file. (Default is `/etc/pfds.json`)
And, configuration file path will be set by env of `PFDS_CONFIG` at run time.
## List
- Add configuration loading
- Fix involving tests
- Make CONFIG_PATH selectable by ENV
- Update README.md
